### PR TITLE
Fix Google Analytics cookie cleanup

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -286,8 +286,8 @@ class CookieConsent {
             if (cookieName.includes('*')) {
                 // Gérer les cookies avec patterns
                 const pattern = cookieName.replace('*', '');
-                Object.keys(document.cookie.split(';')).forEach(key => {
-                    const cookieKey = key.trim().split('=')[0];
+                document.cookie.split(';').forEach(cookie => {
+                    const cookieKey = cookie.trim().split('=')[0];
                     if (cookieKey.startsWith(pattern)) {
                         this.deleteCookie(cookieKey);
                     }


### PR DESCRIPTION
## Summary
- iterate over document cookies directly when clearing GA-related cookies
- trim and extract cookie names before attempting deletion

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');

const cookieStore = {};

global.window = { location: { hostname: 'example.com' } };

global.document = {
  readyState: 'loading',
  addEventListener: () => {},
  body: { appendChild: () => {} },
  getElementById: () => null,
  querySelector: () => null,
  createElement: () => ({ style: {}, innerHTML: '', appendChild: () => {} })
};

Object.defineProperty(document, 'cookie', {
  get() {
    return Object.entries(cookieStore).map(([k,v]) => `${k}=${v}`).join('; ');
  },
  set(v) {
    const [pair] = v.split(';');
    const [name, value] = pair.split('=');
    if (value === '') {
      delete cookieStore[name];
    } else {
      cookieStore[name] = value;
    }
  }
});

global.localStorage = {
  getItem: () => null,
  setItem: () => {},
  removeItem: () => {}
};

global.window.gtag = () => {};

const code = fs.readFileSync('assets/js/cookie-consent.js', 'utf8');
vm.runInThisContext(code);

const CC = window.CookieConsent;
const cc = Object.create(CC.prototype);

['_ga=1', '_gid=2', '_ga_ABC=3', '_gat_gtag_123=4', '_notga=5'].forEach(str => {
  document.cookie = str;
});

console.log('Before:', document.cookie);

cc.clearGoogleAnalyticsCookies();

console.log('After:', document.cookie);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689efc0d69f88325b18cf791d511a2fc