### PR TITLE
Ensure single robots meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,13 +33,11 @@
 <link rel="canonical" href="{{ page.url | absolute_url }}">
 <meta property="og:site_name" content="{{ site.title }}">
 <meta property="og:locale" content="fr_FR">
-<meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
 <!-- Generative Engine Optimisation (GEO) helpers -->
 <meta name="llm:summary" content="{{ page.description | default: site.description }}">
 <meta name="llm:topics" content="formations, e‑books, IA, PrestaShop, développement, prompts, bonnes pratiques">
 <meta name="keywords" content="{{ page.keywords | default: site.keywords }}">
 <meta name="author" content="{{ site.author.name }}">
-<meta name="robots" content="index, follow">
 <meta name="ai-content-type" content="catalog-page">
 <meta name="content-structure" content="faceted-navigation, product-cards, breadcrumb,json-ld">
 <meta name="expertise-domain" content="IA, PrestaShop, Développement">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,16 +7,13 @@
     <meta name="description" content="{{ page.description | default: site.description }}">
     <meta name="keywords" content="{{ page.keywords | default: site.keywords }}">
     <meta name="author" content="{{ site.author.name }}">
-    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+    <meta name="robots" content="{% if page.layout == 'project' or page.url contains '/expertise/' %}index, follow{% else %}index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1{% endif %}">
     <link rel="canonical" href="{{ page.url | absolute_url }}">
     
     <!-- Métadonnées optimisées pour IA génératives (GEO) -->
     <meta name="ai-content-type" content="{% if page.layout == 'post' %}technical-article{% elsif page.layout == 'project' %}portfolio-project{% else %}professional-profile{% endif %}">
     <meta name="expertise-level" content="{% if page.difficulty %}{{ page.difficulty }}{% else %}expert{% endif %}">
     <meta name="content-category" content="{% for category in page.categories %}{{ category }}{% unless forloop.last %}, {% endunless %}{% endfor %}">
-    {% if page.layout == 'project' or page.url contains '/expertise/' %}
-    <meta name="robots" content="index, follow">
-    {% endif %}
     <meta name="target-audience" content="developers, software architects, cto, technical leaders">
     <meta name="reading-time" content="{% if page.layout == 'post' %}{{ content | number_of_words | divided_by: 200 | ceil }} minutes{% else %}2 minutes{% endif %}">
     <meta name="content-freshness" content="{{ page.date | default: site.time | date_to_xmlschema }}">


### PR DESCRIPTION
## Summary
- avoid duplicate robots directives by making the default layout's robots tag conditional
- remove extra robots meta tags from head include so pages emit only one robots directive

## Testing
- `bundle install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efbf0c31483259565d0d9ec22fd52