### PR TITLE
Add dynamic BreadcrumbList JSON-LD

### DIFF
--- a/_includes/breadcrumb-jsonld.html
+++ b/_includes/breadcrumb-jsonld.html
@@ -1,0 +1,51 @@
+{% comment %}
+  Génère un schéma JSON-LD BreadcrumbList lorsque la page possède une hiérarchie.
+  - Utilise `page.breadcrumbs` si défini (liste d'objets `{ name, url }`).
+  - Sinon gère automatiquement les articles (`layout: post`) et produits (`layout: product`).
+{% endcomment %}
+
+{% if page.breadcrumbs %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {% for crumb in page.breadcrumbs %}
+    {
+      "@type": "ListItem",
+      "position": {{ forloop.index }},
+      "name": "{{ crumb.name | escape }}",
+      "item": "{{ crumb.url | absolute_url }}"
+    }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ]
+}
+</script>
+{% elsif page.layout == 'post' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "{{ '/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "{{ '/blog/' | absolute_url }}" }{% if page.categories and page.categories.size > 0 %},
+    { "@type": "ListItem", "position": 3, "name": "{{ page.categories[0] | escape }}", "item": "{{ '/blog/' | append: page.categories[0] | slugify | append: '/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 4, "name": "{{ page.title | escape }}", "item": "{{ page.url | absolute_url }}" }{% else %},
+    { "@type": "ListItem", "position": 3, "name": "{{ page.title | escape }}", "item": "{{ page.url | absolute_url }}" }{% endif %}
+  ]
+}
+</script>
+{% elsif page.layout == 'product' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "{{ '/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 2, "name": "Boutique", "item": "{{ '/boutique/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 3, "name": "{{ page.title | escape }}", "item": "{{ page.url | absolute_url }}" }
+  ]
+}
+</script>
+{% endif %}
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -91,13 +91,7 @@
     "@type": "WebSite",
     "name": "{{ site.title | escape }}",
     "url": "{{ site.url }}"
-  },
-  "breadcrumb": {
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "{{ site.url }}{{ site.baseurl }}/"},
-      {"@type": "ListItem", "position": 2, "name": "Boutique", "item": "{{ site.url }}{{ site.baseurl }}/boutique/"}
-    ]
   }
 }
 </script>
+{% include breadcrumb-jsonld.html %}


### PR DESCRIPTION
## Summary
- add Liquid include generating BreadcrumbList from page type or custom breadcrumbs
- include helper in head to emit JSON-LD only when hierarchy exists

## Testing
- `bundle install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f002ae594832585e391c5d86d3308