### PR TITLE
feat: add alternate language links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,6 +31,12 @@
 <title>{{ site.title }} | {{ page.title }}</title>
 <meta name="description" content="{{ page.description | default: site.description }}">
 <link rel="canonical" href="{{ page.url | absolute_url }}">
+<link rel="alternate" hreflang="fr" href="{{ page.url | absolute_url }}">
+{% if page.alternates %}
+{% for alt in page.alternates %}
+<link rel="alternate" hreflang="{{ alt.lang }}" href="{{ alt.url | absolute_url }}">
+{% endfor %}
+{% endif %}
 <meta property="og:site_name" content="{{ site.title }}">
 <meta property="og:locale" content="fr_FR">
 <!-- Generative Engine Optimisation (GEO) helpers -->


### PR DESCRIPTION
## Summary
- add default French hreflang alternate link
- support configurable alternate language links via `page.alternates`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f0030365c8325a4cd658b61f52ab4