### PR TITLE
feat: preload main stylesheet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -115,7 +115,7 @@
 {% include critical-css.html %}
 
 <!-- Styles -->
-<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" media="print" onload="this.media='all'">
+<link rel="preload" href="{{ '/assets/css/style.css' | relative_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}"></noscript>
 <link rel="stylesheet" href="{{ '/assets/css/homepage-cards.css' | relative_url }}">
 


### PR DESCRIPTION
## Summary
- preload main CSS and provide noscript fallback for faster style loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2c7453e48325acc82c3567a8aa85