### PR TITLE
feat: add cache-busting to css links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -115,9 +115,10 @@
 {% include critical-css.html %}
 
 <!-- Styles -->
-<link rel="preload" href="{{ '/assets/css/style.css' | relative_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}"></noscript>
-<link rel="stylesheet" href="{{ '/assets/css/homepage-cards.css' | relative_url }}">
+{% assign cache_buster = site.time | date: '%s' %}
+<link rel="preload" href="{{ '/assets/css/style.css' | relative_url }}?v={{ cache_buster }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}?v={{ cache_buster }}"></noscript>
+<link rel="stylesheet" href="{{ '/assets/css/homepage-cards.css' | relative_url }}?v={{ cache_buster }}">
 
 <!-- Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- add timestamp-based cache busting for CSS assets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f49381e548325910a3d481ff6a791