### PR TITLE
Simplify site navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,30 +1,8 @@
-- name: Boutique
-  link: /boutique/
-- name: Prestations
-  hidden: true
-  subitems:
-    - name: Services
-      link: /services/
-    - name: Formations
-      link: /formations/
-- name: Blog
+- name: "Compétences"
+  link: /skills/
+- name: "Formations"
+  link: /formations/
+- name: "Blog"
   link: /blog/
-- name: Expertise
-  link: /expertise/
-  subitems:
-    - name: E-commerce
-      link: /expertise/ecommerce/
-    - name: PrestaShop
-      link: /expertise/prestashop/
-    - name: IA
-      link: /expertise/ia/
-    - name: Fullstack
-      link: /expertise/fullstack/
-    - name: Innovation
-      link: /expertise/innovation/
-    - name: Compétences
-      link: /skills/
-    - name: Projets
-      link: /projects/
-- name: FAQ
-  link: /faq/
+- name: "Contact"
+  link: /contact/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,6 +11,8 @@
                     {% for item in site.data.navigation %}
                     <li><a href="{{ item.link | relative_url }}">{{ item.name }}</a></li>
                     {% endfor %}
+                    <li><a href="{{ '/boutique/' | relative_url }}">Boutique</a></li>
+                    <li><a href="{{ '/faq/' | relative_url }}">FAQ</a></li>
                 </ul>
             </div>
             <div class="footer-section">


### PR DESCRIPTION
## Summary
- Reduce header navigation to Compétences, Formations, Blog, and Contact
- Add Boutique and FAQ links to the footer

## Testing
- `ruby scripts/validate_data.rb`
- `bundle exec jekyll build --config _config.yml,_config_github.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a00f7a67b48325aeed7cd016d06251