### PR TITLE
Revamp hero section with new tagline and CTA links

### DIFF
--- a/_includes/home/expertise.html
+++ b/_includes/home/expertise.html
@@ -1,5 +1,5 @@
 <!-- EXPERTISE SECTION MODERNE -->
-<section class="section expertise-section-clean">
+<section class="section expertise-section-clean" id="expertise">
     <div class="container">
         <div class="section-header-clean scroll-reveal">
             <h2 class="section-title-clean">Mes Compétences</h2>

--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -14,7 +14,7 @@
             <div class="hero-content">
                 <div class="hero-header scroll-reveal">
                     <h1 class="hero-title text-gradient-animated">Nicolas Dabène</h1>
-                    <p class="hero-subtitle typing-effect">Développeur Senior Full-Stack | Expert PrestaShop Reconnu | Pionnier IA E-commerce</p>
+                    <p class="hero-subtitle typing-effect">Développeur PHP Senior & Formateur IA, passionné de partage</p>
                     
                     <div class="hero-badges-modern stagger-animation">
                         <div class="animate-item glass-card badge-modern">
@@ -71,14 +71,24 @@
                 
                 <!-- Call to Action Principal -->
                 <div class="hero-cta-section scroll-reveal" id="hero-ctas">
-                    {% assign home_cta = site.data.home.primary_cta %}
-                    <a href="{{ home_cta.link | default: '/boutique/' }}" class="hero-cta-primary btn-primary">
-                        <span class="btn-text">{{ home_cta.label | default: 'Voir les formations' }}</span>
+                    <a href="#expertise" class="hero-cta-primary btn-primary">
+                        <span class="btn-text">Voir mes compétences</span>
                         <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
                             <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
                         </svg>
                     </a>
-                    <a href="/contact/" class="btn-secondary" style="margin-left:.5rem">Me contacter</a>
+                    <a href="#formations" class="btn-secondary" style="margin-left:.5rem">
+                        <span class="btn-text">Découvrir les formations</span>
+                        <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+                            <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
+                        </svg>
+                    </a>
+                    <a href="#publications" class="btn-secondary" style="margin-left:.5rem">
+                        <span class="btn-text">Lire le blog</span>
+                        <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+                            <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
+                        </svg>
+                    </a>
                 </div>
             </div>
         </div>

--- a/_includes/home/publications.html
+++ b/_includes/home/publications.html
@@ -1,5 +1,5 @@
 <!-- PUBLICATIONS SECTION MODERNE -->
-<section class="section publications-section">
+<section class="section publications-section" id="publications">
     <div class="container">
         <div class="section-header-clean scroll-reveal">
             <h2 class="section-title-clean">Mes Publications</h2>

--- a/index.md
+++ b/index.md
@@ -1,14 +1,11 @@
 ---
 layout: default
-title: "Nicolas Dabène - Senior PHP Developer & AI Orchestrator | Expert PrestaShop"
-description: "15+ ans d'expérience en développement e-commerce. Modules PrestaShop,
-  architecture e-commerce, AI-assisted development."
-keywords: "senior php developer, prestashop expert, ai orchestrator, symfony, e-commerce
-  architecture, php fullstack"
+title: "Nicolas Dabène - Développeur PHP Senior & Formateur IA, passionné de partage"
+description: "15+ ans d'expérience en développement e-commerce. Modules PrestaShop, architecture e-commerce, formation IA et partage de connaissances."
+keywords: "senior php developer, prestashop expert, ai orchestrator, symfony, e-commerce architecture, php fullstack"
 no_bg: true
 body_class: homepage-modern
-llm_summary: 15+ ans d'expérience en développement e-commerce. Modules 
-  PrestaShop, architecture e-commerce, AI-assisted development.
+llm_summary: 15+ ans d'expérience en développement e-commerce. Modules PrestaShop, architecture e-commerce, formation IA et partage de connaissances.
 llm_topics:
 - senior php developer
 - prestashop expert


### PR DESCRIPTION
## Summary
- Update hero tagline to "Développeur PHP Senior & Formateur IA, passionné de partage"
- Replace hero CTAs with links to skills, formations, and blog
- Add anchors for expertise and publications sections to match new CTAs
- Align homepage metadata with new positioning

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a00f7b0e208325a939e19fff23ef6a