### PR TITLE
Add footer summary links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,10 +25,19 @@
                 </div>
             </div>
         </div>
+
+        <div class="footer-summary">
+            <p>
+                <a href="{{ '/skills/' | relative_url }}">Découvrir mes compétences</a> |
+                <a href="{{ '/blog/' | relative_url }}">Lire mes articles</a> |
+                <a href="{{ '/formations/' | relative_url }}">Suivre une formation</a>
+            </p>
+        </div>
+
         <div class="footer-bottom">
-            <p>&copy; {{ site.time | date: "%Y" }} Nicolas Dabène. Tous droits réservés. | 
-               <a href="/politique-cookies/" class="cookie-preferences-link">Politique de cookies</a> | 
-               <a href="#cookie-preferences" class="cookie-preferences-link">Préférences cookies</a> | 
+            <p>&copy; {{ site.time | date: "%Y" }} Nicolas Dabène. Tous droits réservés. |
+               <a href="/politique-cookies/" class="cookie-preferences-link">Politique de cookies</a> |
+               <a href="#cookie-preferences" class="cookie-preferences-link">Préférences cookies</a> |
                <a href="/cgu-boutique/">CGU Boutique</a>
             </p>
         </div>


### PR DESCRIPTION
## Summary
- add summary section in footer linking to skills, blog, and formations pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00fa5717c8325b9ef600f991d25a3