### PR TITLE
feat: track last modified dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Gem GitHub Pages - assure la compatibilité avec la version exacte
 gem "github-pages", group: :jekyll_plugins
+gem "jekyll-last-modified-at", group: :jekyll_plugins
 
 # Gem pour Windows (optionnel)
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :x64_mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.2)
+      jekyll (>= 3.7, < 5.0)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -281,6 +283,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-last-modified-at
   wdm (>= 0.1.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-sass-converter
+  - jekyll-last-modified-at
 
 # Boutique (achat en ligne)
 # Mettre à true quand Lemon Squeezy est validé

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,9 +6,10 @@ layout: null
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   
   <!-- Page d'accueil (exclue des pages loop pour éviter duplication) -->
+  {% assign home = site.pages | where: "url", "/" | first %}
   <url>
     <loc>{{ site.url }}/</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <lastmod>{{ home.last_modified_at | date_to_xmlschema }}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -20,9 +21,9 @@ layout: null
       <loc>{{ page.url | prepend: site.url }}</loc>
       {% if page.date %}
         <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+        {% else %}
+          <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
       {% if page.sitemap.changefreq %}
         <changefreq>{{ page.sitemap.changefreq }}</changefreq>
       {% else %}
@@ -63,9 +64,9 @@ layout: null
       <loc>{{ project.url | prepend: site.url }}</loc>
       {% if project.date %}
         <lastmod>{{ project.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+        {% else %}
+          <lastmod>{{ project.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
       <changefreq>{% if project.sitemap.changefreq %}{{ project.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
         <priority>{% if project.sitemap.priority %}{{ project.sitemap.priority }}{% else %}0.8{% endif %}</priority>
       {% assign project_image = project.image | default: project.hero_image %}
@@ -83,9 +84,9 @@ layout: null
       <loc>{{ case_study.url | prepend: site.url }}</loc>
       {% if case_study.date %}
         <lastmod>{{ case_study.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+        {% else %}
+          <lastmod>{{ case_study.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
       <changefreq>{% if case_study.sitemap.changefreq %}{{ case_study.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
         <priority>{% if case_study.sitemap.priority %}{{ case_study.sitemap.priority }}{% else %}0.8{% endif %}</priority>
       {% assign cs_image = case_study.image | default: case_study.hero_image %}


### PR DESCRIPTION
## Summary
- add jekyll-last-modified-at plugin
- use page last modified timestamps in sitemap

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a05529478c8325b819c190511f4cb3