### PR TITLE
Adjust sitemap defaults and priorities

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,7 +31,11 @@ layout: null
       {% if page.sitemap.priority %}
         <priority>{{ page.sitemap.priority }}</priority>
       {% else %}
-        <priority>0.8</priority>
+        {% if page.url == '/contact/' or page.url == '/blog/' %}
+          <priority>0.9</priority>
+        {% else %}
+          <priority>0.8</priority>
+        {% endif %}
       {% endif %}
       {% if page.image %}
         <image:image>
@@ -47,7 +51,7 @@ layout: null
     <url>
       <loc>{{ post.url | prepend: site.url }}</loc>
       <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
-        <changefreq>{% if post.sitemap.changefreq %}{{ post.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
+        <changefreq>{% if post.sitemap.changefreq %}{{ post.sitemap.changefreq }}{% else %}weekly{% endif %}</changefreq>
         <priority>{% if post.featured %}0.9{% elsif post.sitemap.priority %}{{ post.sitemap.priority }}{% else %}0.7{% endif %}</priority>
         {% if post.image %}
           <image:image>


### PR DESCRIPTION
## Summary
- Set blog posts to default weekly change frequency and keep priority at 0.7
- Add higher sitemap priority for key pages like Contact and Blog
- Ensure static pages, projects and case studies retain monthly/yearly defaults

## Testing
- `npm run test-sitemap`


------
https://chatgpt.com/codex/tasks/task_e_68a05527ae50832590c5db94f3581fd4