### PR TITLE
Exclude internal docs from sitemap

### DIFF
--- a/BLOG_INSTRUCTIONS.md
+++ b/BLOG_INSTRUCTIONS.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # 📝 Instructions pour la Génération d'Articles de Blog
 
 **Contexte :** Site Jekyll portfolio de Nicolas Dabène - Senior PHP Developer & AI Orchestrator  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # CLAUDE.md - Règles de Développement
 
 Ce fichier définit les conventions et règles pour maintenir la cohérence du développement du portfolio de Nicolas Dabène.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # Project: Modernization of the Projects Page
 
 ## Goal

--- a/SERIES_GUIDE.md
+++ b/SERIES_GUIDE.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # Guide d'utilisation du système de séries
 
 Ce guide explique comment utiliser le système de séries d'articles que j'ai mis en place pour votre blog Jekyll.

--- a/rework-article.md
+++ b/rework-article.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # 🎨 Rework Articles de Blog - Plan d'Amélioration UX/UI
 
 ## 📋 Objectif

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -15,7 +15,7 @@ layout: null
   
   <!-- Pages statiques -->
   {% for page in site.pages %}
-    {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".json" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
+    {% unless page.sitemap.exclude or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".json" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
     <url>
       <loc>{{ page.url | prepend: site.url }}</loc>
       {% if page.date %}

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,7 @@
+---
+sitemap: { exclude: yes }
+---
+
 # Plan d'action SEO & GEO pour nicolas-dabene.fr
 
 ## 🎯 Objectifs repositionnés


### PR DESCRIPTION
## Summary
- add `sitemap: { exclude: yes }` front matter to internal markdown docs
- update sitemap template to honor `page.sitemap.exclude`
- rebuild sitemap to remove internal guides from generated file

## Testing
- `bash update-sitemap.sh`
- `grep -n "SERIES_GUIDE" _site/sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a055257e988325ba469e474fd7401d