### PR TITLE
Use jekyll-last-modified-at for sitemap lastmod

### DIFF
--- a/sitemap_case_studies.xml
+++ b/sitemap_case_studies.xml
@@ -7,11 +7,7 @@ layout: null
   {% for case_study in site.case_studies %}
     <url>
       <loc>{{ case_study.url | prepend: site.url }}</loc>
-      {% if case_study.date %}
-        <lastmod>{{ case_study.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+      <lastmod>{{ case_study.last_modified_at | date_to_xmlschema }}</lastmod>
       <changefreq>{% if case_study.sitemap.changefreq %}{{ case_study.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
       <priority>{% if case_study.sitemap.priority %}{{ case_study.sitemap.priority }}{% else %}0.8{% endif %}</priority>
       {% assign cs_image = case_study.image | default: case_study.hero_image %}

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -2,21 +2,25 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
+{% assign pages_sitemap = site.pages | where: "name", "sitemap_pages.xml" | first %}
+{% assign posts_sitemap = site.pages | where: "name", "sitemap_posts.xml" | first %}
+{% assign projects_sitemap = site.pages | where: "name", "sitemap_projects.xml" | first %}
+{% assign case_studies_sitemap = site.pages | where: "name", "sitemap_case_studies.xml" | first %}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>{{ site.url }}/sitemap_pages.xml</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <lastmod>{{ pages_sitemap.last_modified_at | date_to_xmlschema }}</lastmod>
   </sitemap>
   <sitemap>
     <loc>{{ site.url }}/sitemap_posts.xml</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <lastmod>{{ posts_sitemap.last_modified_at | date_to_xmlschema }}</lastmod>
   </sitemap>
   <sitemap>
     <loc>{{ site.url }}/sitemap_projects.xml</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <lastmod>{{ projects_sitemap.last_modified_at | date_to_xmlschema }}</lastmod>
   </sitemap>
   <sitemap>
     <loc>{{ site.url }}/sitemap_case_studies.xml</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <lastmod>{{ case_studies_sitemap.last_modified_at | date_to_xmlschema }}</lastmod>
   </sitemap>
 </sitemapindex>

--- a/sitemap_pages.xml
+++ b/sitemap_pages.xml
@@ -8,11 +8,7 @@ layout: null
     {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
     <url>
       <loc>{{ page.url | prepend: site.url }}</loc>
-      {% if page.date %}
-        <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+      <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
       <changefreq>{% if page.sitemap.changefreq %}{{ page.sitemap.changefreq }}{% else %}monthly{% endif %}</changefreq>
       <priority>{% if page.sitemap.priority %}{{ page.sitemap.priority }}{% else %}0.8{% endif %}</priority>
       {% if page.image %}

--- a/sitemap_posts.xml
+++ b/sitemap_posts.xml
@@ -7,7 +7,7 @@ layout: null
   {% for post in site.posts %}
     <url>
       <loc>{{ post.url | prepend: site.url }}</loc>
-      <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      <lastmod>{{ post.last_modified_at | date_to_xmlschema }}</lastmod>
       <changefreq>{% if post.sitemap.changefreq %}{{ post.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
       <priority>{% if post.featured %}0.9{% elsif post.sitemap.priority %}{{ post.sitemap.priority }}{% else %}0.7{% endif %}</priority>
       {% if post.image %}

--- a/sitemap_projects.xml
+++ b/sitemap_projects.xml
@@ -7,11 +7,7 @@ layout: null
   {% for project in site.projects %}
     <url>
       <loc>{{ project.url | prepend: site.url }}</loc>
-      {% if project.date %}
-        <lastmod>{{ project.date | date_to_xmlschema }}</lastmod>
-      {% else %}
-        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-      {% endif %}
+      <lastmod>{{ project.last_modified_at | date_to_xmlschema }}</lastmod>
       <changefreq>{% if project.sitemap.changefreq %}{{ project.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
       <priority>{% if project.sitemap.priority %}{{ project.sitemap.priority }}{% else %}0.8{% endif %}</priority>
       {% assign project_image = project.image | default: project.hero_image %}


### PR DESCRIPTION
## Summary
- replace lastmod generation in all sitemaps with `last_modified_at`
- include last modification dates for sitemap index entries

## Testing
- `bundle exec jekyll build --config _config.yml,_config_github.yml`
- verified each sitemap URL has a lastmod entry

------
https://chatgpt.com/codex/tasks/task_e_68a07a508ed08325952e752b974548e9