### PR TITLE
feat: add case studies permalink and redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sass-converter
   - jekyll-last-modified-at
+  - jekyll-redirect-from
 
 # Boutique (achat en ligne)
 # Mettre à true quand Lemon Squeezy est validé

--- a/pages/case-studies.html
+++ b/pages/case-studies.html
@@ -1,6 +1,10 @@
 ---
 layout: page
 title: Case Studies
+permalink: /case-studies/
+redirect_from:
+  - /case-studies.html
+  - /pages/case-studies.html
 description: "In-depth case studies showcasing complex projects, technical challenges,
   and measurable business impact delivered by Nicolas Dabène."
 keywords: "case studies, project analysis, technical solutions, business impact, senior

--- a/sitemap_pages.xml
+++ b/sitemap_pages.xml
@@ -5,7 +5,7 @@ layout: null
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   {% for page in site.pages %}
-    {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
+    {% unless page.sitemap == false or page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
     <url>
       <loc>{{ page.url | prepend: site.url }}</loc>
       {% if page.date %}


### PR DESCRIPTION
## Summary
- add canonical permalink and redirects for case studies index page
- enable jekyll-redirect-from plugin to handle 301 redirects
- exclude redirect pages from sitemap generation

## Testing
- `./update-sitemap.sh`
- `scripts/test-sitemap.sh` *(fails: Sitemap non généré)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a52c65c8325b2f0a6aca8021a48