### PR TITLE
Refine sitemap changefreq and priority defaults

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,7 @@ defaults:
     values:
       layout: post
       sitemap:
-        changefreq: "monthly"
+        changefreq: "weekly"
         priority: 0.7
   - scope:
       path: ""
@@ -130,14 +130,14 @@ defaults:
     values:
       sitemap:
         changefreq: "yearly"
-        priority: 0.8
+        priority: 0.6
   - scope:
       path: ""
       type: "case_studies"
     values:
       sitemap:
         changefreq: "yearly"
-        priority: 0.8
+        priority: 0.5
   - scope:
       path: "index.md"
     values:

--- a/sitemap_case_studies.xml
+++ b/sitemap_case_studies.xml
@@ -12,8 +12,8 @@ layout: null
       {% else %}
         <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
       {% endif %}
-      <changefreq>{% if case_study.sitemap.changefreq %}{{ case_study.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
-      <priority>{% if case_study.sitemap.priority %}{{ case_study.sitemap.priority }}{% else %}0.8{% endif %}</priority>
+        <changefreq>{% if case_study.sitemap.changefreq %}{{ case_study.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
+        <priority>{% if case_study.sitemap.priority %}{{ case_study.sitemap.priority }}{% else %}0.5{% endif %}</priority>
       {% assign cs_image = case_study.image | default: case_study.hero_image %}
       {% if cs_image %}
         <image:image>

--- a/sitemap_pages.xml
+++ b/sitemap_pages.xml
@@ -4,8 +4,9 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  {% assign pillar_pages = "/services/,/expertise/,/formations/,/projects/,/skills/,/boutique/,/about/,/contact/,/publications/,/case-studies.html,/blog/" | split: "," %}
   {% for page in site.pages %}
-    {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.name contains "robots" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
+    {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.name contains "robots" %}
     <url>
       <loc>{{ page.url | prepend: site.url }}</loc>
       {% if page.date %}
@@ -14,7 +15,15 @@ layout: null
         <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
       {% endif %}
       <changefreq>{% if page.sitemap.changefreq %}{{ page.sitemap.changefreq }}{% else %}monthly{% endif %}</changefreq>
-      <priority>{% if page.sitemap.priority %}{{ page.sitemap.priority }}{% else %}0.8{% endif %}</priority>
+      {% assign page_priority = 0.8 %}
+      {% if page.url == "/" %}
+        {% assign page_priority = 1.0 %}
+      {% elsif pillar_pages contains page.url %}
+        {% assign page_priority = 0.9 %}
+      {% elsif page.url == "/faq/" %}
+        {% assign page_priority = 0.7 %}
+      {% endif %}
+      <priority>{% if page.sitemap.priority %}{{ page.sitemap.priority }}{% else %}{{ page_priority }}{% endif %}</priority>
       {% if page.image %}
         <image:image>
           <image:loc>{{ page.image | prepend: site.url }}</image:loc>
@@ -23,4 +32,4 @@ layout: null
     </url>
     {% endunless %}
   {% endfor %}
-</urlset>
+  </urlset>

--- a/sitemap_posts.xml
+++ b/sitemap_posts.xml
@@ -8,7 +8,7 @@ layout: null
     <url>
       <loc>{{ post.url | prepend: site.url }}</loc>
       <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
-      <changefreq>{% if post.sitemap.changefreq %}{{ post.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
+      <changefreq>{% if post.sitemap.changefreq %}{{ post.sitemap.changefreq }}{% else %}weekly{% endif %}</changefreq>
       <priority>{% if post.featured %}0.9{% elsif post.sitemap.priority %}{{ post.sitemap.priority }}{% else %}0.7{% endif %}</priority>
       {% if post.image %}
         <image:image>

--- a/sitemap_projects.xml
+++ b/sitemap_projects.xml
@@ -12,8 +12,8 @@ layout: null
       {% else %}
         <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
       {% endif %}
-      <changefreq>{% if project.sitemap.changefreq %}{{ project.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
-      <priority>{% if project.sitemap.priority %}{{ project.sitemap.priority }}{% else %}0.8{% endif %}</priority>
+        <changefreq>{% if project.sitemap.changefreq %}{{ project.sitemap.changefreq }}{% else %}yearly{% endif %}</changefreq>
+        <priority>{% if project.sitemap.priority %}{{ project.sitemap.priority }}{% else %}0.6{% endif %}</priority>
       {% assign project_image = project.image | default: project.hero_image %}
       {% if project_image %}
         <image:image>


### PR DESCRIPTION
## Summary
- set posts changefreq to weekly by default
- customize page priorities: 1.0 for home, 0.9 for pillar pages, 0.7 for FAQ
- lower project and case study sitemap priority to reflect SEO strategy

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a07a54843c8325bd5c26730142f7bb