### PR TITLE
Add dedicated images sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,7 @@ include:
   - sitemap_posts.xml
   - sitemap_projects.xml
   - sitemap_case_studies.xml
+  - sitemap_images.xml
   - robots.txt
 
 # Google Analytics

--- a/sitemap_images.xml
+++ b/sitemap_images.xml
@@ -1,0 +1,51 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  {% for post in site.posts %}
+    {% if post.image %}
+    <url>
+      <loc>{{ post.url | prepend: site.url }}</loc>
+      <image:image>
+        <image:loc>{{ post.image | prepend: site.url }}</image:loc>
+      </image:image>
+    </url>
+    {% endif %}
+  {% endfor %}
+  {% for case_study in site.case_studies %}
+    {% assign cs_image = case_study.image | default: case_study.hero_image %}
+    {% if cs_image %}
+    <url>
+      <loc>{{ case_study.url | prepend: site.url }}</loc>
+      <image:image>
+        <image:loc>{{ cs_image | prepend: site.url }}</image:loc>
+      </image:image>
+    </url>
+    {% endif %}
+  {% endfor %}
+  {% for project in site.projects %}
+    {% assign project_image = project.image | default: project.hero_image %}
+    {% if project_image %}
+    <url>
+      <loc>{{ project.url | prepend: site.url }}</loc>
+      <image:image>
+        <image:loc>{{ project_image | prepend: site.url }}</image:loc>
+      </image:image>
+    </url>
+    {% endif %}
+  {% endfor %}
+  {% for page in site.pages %}
+    {% unless page.sitemap.exclude == "yes" or page.name contains ".xml" or page.name contains ".txt" or page.name contains ".js" or page.name contains ".sh" or page.url == "/" or page.name == "index.md" or page.name == "index.html" %}
+      {% if page.image %}
+      <url>
+        <loc>{{ page.url | prepend: site.url }}</loc>
+        <image:image>
+          <image:loc>{{ page.image | prepend: site.url }}</image:loc>
+        </image:image>
+      </url>
+      {% endif %}
+    {% endunless %}
+  {% endfor %}
+</urlset>

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -19,4 +19,8 @@ layout: null
     <loc>{{ site.url }}/sitemap_case_studies.xml</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
   </sitemap>
+  <sitemap>
+    <loc>{{ site.url }}/sitemap_images.xml</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+  </sitemap>
 </sitemapindex>

--- a/update-sitemap.sh
+++ b/update-sitemap.sh
@@ -21,7 +21,7 @@ if [ -f "_site/sitemap_index.xml" ]; then
     # Affichage des stats
     echo "📊 Statistiques du sitemap :"
     total_urls=0
-    for file in sitemap_pages.xml sitemap_posts.xml sitemap_projects.xml sitemap_case_studies.xml; do
+    for file in sitemap_pages.xml sitemap_posts.xml sitemap_projects.xml sitemap_case_studies.xml sitemap_images.xml; do
         if [ -f "_site/$file" ]; then
             count=$(grep -c '<url>' "_site/$file")
             total_urls=$((total_urls + count))


### PR DESCRIPTION
## Summary
- add `sitemap_images.xml` to list images from posts, case studies, projects, and pages
- register the new sitemap in `sitemap_index.xml` and Jekyll config
- extend update script to include images sitemap in stats

## Testing
- `bundle exec jekyll build --config _config.yml,_config_github.yml`
- `npm run test-sitemap` *(fails: "❌ Erreur : Sitemap non généré")*

------
https://chatgpt.com/codex/tasks/task_e_68a07a56dcd08325b740da27464478bd