### PR TITLE
Split post sitemap by year

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ exclude:
 include:
   - sitemap_index.xml
   - sitemap_pages.xml
-  - sitemap_posts.xml
+  - sitemap_posts_2025.xml
   - sitemap_projects.xml
   - sitemap_case_studies.xml
   - robots.txt

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -7,10 +7,13 @@ layout: null
     <loc>{{ site.url }}/sitemap_pages.xml</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
   </sitemap>
+  {% assign years = site.posts | group_by_exp: "post", "post.date | date: '%Y'" | sort: "name" | reverse %}
+  {% for year in years %}
   <sitemap>
-    <loc>{{ site.url }}/sitemap_posts.xml</loc>
+    <loc>{{ site.url }}/sitemap_posts_{{ year.name }}.xml</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
   </sitemap>
+  {% endfor %}
   <sitemap>
     <loc>{{ site.url }}/sitemap_projects.xml</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>

--- a/sitemap_posts_2025.xml
+++ b/sitemap_posts_2025.xml
@@ -1,10 +1,13 @@
 ---
 layout: null
+year: '2025'
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   {% for post in site.posts %}
+    {% assign post_year = post.date | date: "%Y" %}
+    {% if post_year == page.year %}
     <url>
       <loc>{{ post.url | prepend: site.url }}</loc>
       <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
@@ -16,5 +19,6 @@ layout: null
         </image:image>
       {% endif %}
     </url>
+    {% endif %}
   {% endfor %}
 </urlset>

--- a/update-sitemap.sh
+++ b/update-sitemap.sh
@@ -21,7 +21,7 @@ if [ -f "_site/sitemap_index.xml" ]; then
     # Affichage des stats
     echo "📊 Statistiques du sitemap :"
     total_urls=0
-    for file in sitemap_pages.xml sitemap_posts.xml sitemap_projects.xml sitemap_case_studies.xml; do
+    for file in sitemap_pages.xml sitemap_posts_*.xml sitemap_projects.xml sitemap_case_studies.xml; do
         if [ -f "_site/$file" ]; then
             count=$(grep -c '<url>' "_site/$file")
             total_urls=$((total_urls + count))
@@ -35,4 +35,3 @@ else
 fi
 
 echo "🎉 Mise à jour terminée !"
-


### PR DESCRIPTION
## Summary
- Generate `sitemap_posts_YYYY.xml` files beginning with 2025 and filter posts by year
- Auto-reference yearly post sitemaps from `sitemap_index.xml`
- Expand sitemap update script to tally all yearly sitemap files

## Testing
- `bash update-sitemap.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a07a5a6114832595dc921bd88aff40