### PR TITLE
Add jekyll sitemap plugin and configure last modified format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Gem GitHub Pages - assure la compatibilité avec la version exacte
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-last-modified-at", group: :jekyll_plugins
+gem "jekyll-sitemap", group: :jekyll_plugins
 
 # Gem pour Windows (optionnel)
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :x64_mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-last-modified-at
+  jekyll-sitemap
   wdm (>= 0.1.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,10 @@ plugins:
   - jekyll-sass-converter
   - jekyll-last-modified-at
   - jekyll-redirect-from
+  - jekyll-sitemap
+
+last-modified-at:
+  date-format: "%Y-%m-%dT%H:%M:%S%:z"
 
 # Boutique (achat en ligne)
 # Mettre à true quand Lemon Squeezy est validé


### PR DESCRIPTION
## Summary
- include `jekyll-sitemap` in bundle and Jekyll plugins
- configure `last-modified-at` to output ISO-8601 timestamps

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: No such file or directory - redirect.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac3149a08325b493b956828ef891