### PR TITLE
Filter out redirect pages in sitemap index

### DIFF
--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-{% assign filtered_pages = site.pages | reject: "name", "redirect.html" | reject: "name", "redirects.json" %}
+{% assign filtered_pages = site.pages | where_exp: "p", "p.name != 'redirect.html'" | where_exp: "p", "p.name != 'redirects.json'" %}
 {% assign pages_last = filtered_pages | map: "last_modified_at" | compact | sort | last | default: site.time %}
 {% assign posts_last = site.posts | map: "last_modified_at" | compact | sort | last | default: site.time %}
 {% assign projects_last = site.projects | map: "last_modified_at" | compact | sort | last | default: site.time %}


### PR DESCRIPTION
## Summary
- refine sitemap filtering using Liquid `where_exp` to exclude `redirect.html` and `redirects.json`

## Testing
- `bundle exec jekyll serve` *(fails: No such file or directory - sitemap.xml does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b4c169e883258dd55e285142a795