### PR TITLE
feat: track page view when analytics consent granted

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -7,6 +7,9 @@ class CookieConsent {
     constructor() {
         this.cookieName = 'ndabene_cookie_consent';
         this.consentData = this.getConsentData();
+        this.analyticsConsentGranted = this.consentData &&
+            this.consentData.preferences &&
+            this.consentData.preferences.analytics === true;
         this.init();
     }
 
@@ -231,9 +234,17 @@ class CookieConsent {
 
     enableGoogleAnalytics() {
         if (window.gtag) {
+            const wasGranted = this.analyticsConsentGranted;
             window.gtag('consent', 'update', {
                 'analytics_storage': 'granted'
             });
+            if (!wasGranted) {
+                window.gtag('event', 'page_view', {
+                    page_location: location.href,
+                    page_title: document.title
+                });
+            }
+            this.analyticsConsentGranted = true;
         }
     }
 
@@ -243,6 +254,7 @@ class CookieConsent {
                 'analytics_storage': 'denied'
             });
         }
+        this.analyticsConsentGranted = false;
     }
 
     showNotification(message) {


### PR DESCRIPTION
## Summary
- trigger GA page view after consent granted
- track consent state to avoid duplicate analytics hits

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0c154a9308325a21f293c24dc0ae6