### PR TITLE
fix: update GA consent storages

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -232,7 +232,10 @@ class CookieConsent {
     enableGoogleAnalytics() {
         if (window.gtag) {
             window.gtag('consent', 'update', {
-                'analytics_storage': 'granted'
+                'analytics_storage': 'granted',
+                'ad_storage': 'granted',
+                'ad_user_data': 'granted',
+                'ad_personalization': 'granted'
             });
         }
     }
@@ -240,7 +243,10 @@ class CookieConsent {
     disableGoogleAnalytics() {
         if (window.gtag) {
             window.gtag('consent', 'update', {
-                'analytics_storage': 'denied'
+                'analytics_storage': 'denied',
+                'ad_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied'
             });
         }
     }


### PR DESCRIPTION
## Summary
- update Google Analytics consent to grant all storage types
- deny all GA-related storages when consent is revoked

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0c15615e48325992f13ca18e179ef